### PR TITLE
Handle fallback data and messaging in web dashboard

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,14 +4,25 @@
 <div style="padding:8px">
   <h1>نقشه شبکه مسائل</h1>
   <div id="cy" style="width:100%;height:70vh;border:1px solid #ddd;border-radius:8px"></div>
+  <div id="msg" style="padding:8px;color:#666"></div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
 <script src="https://unpkg.com/cytoscape@3.28.0/dist/cytoscape.min.js"></script>
 <script>
 async function loadCSV(p){ const r=await fetch(p); return Papa.parse(await r.text(),{header:true}).data; }
 (async()=>{
-  const problems=await loadCSV('/data/problems_enriched.csv').catch(()=>[]);
-  const edges=await loadCSV('/data/edges.csv').catch(()=>[]);
+  const problems=await loadCSV('data/problems_enriched.csv')
+    .catch(()=> loadCSV('data/problems.csv').then(rows=>{
+      return rows.map(r=>{
+        const U=+r.uncertainty||0, I=+r.impact||0;
+        const route = (I>=3 && U<3) ? 'COMMIT'
+                   : (I>=3 && U>=3) ? 'EXPLORE'
+                   : (I<3  && U>=3) ? 'PARK'
+                   : 'DEFER/AUTO';
+        return { ...r, route };
+      });
+    }).catch(()=>[]));
+  const edges=await loadCSV('data/edges.csv').catch(()=>[]);
   const nodes=problems.map(p=>({ data:{ id:p.id, label:p.title, route:p.route||'NA', sector:p.sector||'other' } }));
   const links=edges.map(e=>({ data:{ id:e.source+'_'+e.target, source:e.source, target:e.target, weight:+e.weight||1 } }));
   const cy = cytoscape({ container:document.getElementById('cy'), elements:[...nodes,...links],
@@ -21,6 +32,10 @@ async function loadCSV(p){ const r=await fetch(p); return Papa.parse(await r.tex
       { selector:'node[route = "EXPLORE"]', style:{ 'background-color':'#f59e0b' } },
       { selector:'node[route = "COMMIT"]',  style:{ 'background-color':'#10b981' } }
     ]});
+  if(nodes.length===0){
+    document.getElementById('msg').textContent =
+      'داده‌ای پیدا نشد. منتظر خروجی CI بمانید یا فایل‌های data/* را پر کنید.';
+  }
 })();
 </script>
 </html>


### PR DESCRIPTION
## Summary
- switch dashboard CSV requests to relative paths so static hosting works
- fall back to computing a route when only problems.csv is available
- surface a user-facing message when no data is loaded

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db8bf788108328a0fff21c775316a1