### PR TITLE
Add docs write permission to analyze workflow

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -6,6 +6,8 @@ on:
     paths: ["data/**","analysis/python/**","web/**"]
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant the analyze workflow write access to repository contents so CI can update docs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db8c8840448328abdcd84cc201de2f