### PR TITLE
Add MICMAC-based coloring to network view

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,23 +4,60 @@
 <div style="padding:8px">
   <h1>نقشه شبکه مسائل</h1>
   <div id="cy" style="width:100%;height:70vh;border:1px solid #ddd;border-radius:8px"></div>
+  <div id="msg" style="padding:8px;color:#666"></div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
 <script src="https://unpkg.com/cytoscape@3.28.0/dist/cytoscape.min.js"></script>
 <script>
-async function loadCSV(p){ const r=await fetch(p); return Papa.parse(await r.text(),{header:true}).data; }
+async function loadCSV(p){
+  const r = await fetch(p);
+  if(!r.ok) throw new Error('Failed to load '+p);
+  return Papa.parse(await r.text(),{header:true,skipEmptyLines:true}).data;
+}
 (async()=>{
-  const problems=await loadCSV('/data/problems_enriched.csv').catch(()=>[]);
-  const edges=await loadCSV('/data/edges.csv').catch(()=>[]);
-  const nodes=problems.map(p=>({ data:{ id:p.id, label:p.title, route:p.route||'NA', sector:p.sector||'other' } }));
+  const problems=await loadCSV('data/problems_enriched.csv')
+    .catch(()=> loadCSV('data/problems.csv').then(rows=>{
+      return rows.map(r=>{
+        const U=+r.uncertainty||0, I=+r.impact||0;
+        const route = (I>=3 && U<3) ? 'COMMIT'
+                   : (I>=3 && U>=3) ? 'EXPLORE'
+                   : (I<3  && U>=3) ? 'PARK'
+                   : 'DEFER/AUTO';
+        return { ...r, route };
+      });
+    }).catch(()=>[]));
+  const edges=await loadCSV('data/edges.csv').catch(()=>[]);
+  let micmacById=null;
+  try{
+    const micmacRows=await loadCSV('docs/data/micmac.csv');
+    const cleaned=micmacRows.filter(r=>r.id && r.micmac_class);
+    if(cleaned.length){
+      micmacById=Object.fromEntries(cleaned.map(r=>[r.id,r.micmac_class]));
+    }
+  }catch(e){
+    micmacById=null;
+  }
+  const nodes=problems.map(p=>({ data:{ id:p.id, label:p.title, route:p.route||'NA', sector:p.sector||'other', micmac:micmacById?.[p.id]||null } }));
   const links=edges.map(e=>({ data:{ id:e.source+'_'+e.target, source:e.source, target:e.target, weight:+e.weight||1 } }));
+  const baseStyle=[
+    { selector:'node', style:{ 'label':'data(label)','font-size':10,'background-color':'#888','text-wrap':'wrap','text-max-width':120 } },
+    { selector:'edge', style:{ 'curve-style':'bezier','width':'data(weight)','line-color':'#bbb' } }
+  ];
+  const style = micmacById ? baseStyle.concat([
+    { selector:'node[micmac = "Driver"]', style:{ 'background-color':'#065f46' } },
+    { selector:'node[micmac = "Linkage"]', style:{ 'background-color':'#d97706' } },
+    { selector:'node[micmac = "Dependent"]', style:{ 'background-color':'#2563eb' } },
+    { selector:'node[micmac = "Autonomous"]', style:{ 'background-color':'#9ca3af' } }
+  ]) : baseStyle.concat([
+    { selector:'node[route = "EXPLORE"]', style:{ 'background-color':'#f59e0b' } },
+    { selector:'node[route = "COMMIT"]',  style:{ 'background-color':'#10b981' } }
+  ]);
   const cy = cytoscape({ container:document.getElementById('cy'), elements:[...nodes,...links],
-    layout:{ name:'cose' }, style:[
-      { selector:'node', style:{ 'label':'data(label)','font-size':10,'background-color':'#888','text-wrap':'wrap','text-max-width':120 } },
-      { selector:'edge', style:{ 'curve-style':'bezier','width':'data(weight)','line-color':'#bbb' } },
-      { selector:'node[route = "EXPLORE"]', style:{ 'background-color':'#f59e0b' } },
-      { selector:'node[route = "COMMIT"]',  style:{ 'background-color':'#10b981' } }
-    ]});
+    layout:{ name:'cose' }, style });
+  if(nodes.length===0){
+    document.getElementById('msg').textContent =
+      'داده‌ای پیدا نشد. منتظر خروجی CI بمانید یا فایل‌های data/* را پر کنید.';
+  }
 })();
 </script>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,11 @@
 <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
 <script src="https://unpkg.com/cytoscape@3.28.0/dist/cytoscape.min.js"></script>
 <script>
-async function loadCSV(p){ const r=await fetch(p); return Papa.parse(await r.text(),{header:true}).data; }
+async function loadCSV(p){
+  const r = await fetch(p);
+  if(!r.ok) throw new Error('Failed to load '+p);
+  return Papa.parse(await r.text(),{header:true,skipEmptyLines:true}).data;
+}
 (async()=>{
   const problems=await loadCSV('data/problems_enriched.csv')
     .catch(()=> loadCSV('data/problems.csv').then(rows=>{
@@ -23,15 +27,33 @@ async function loadCSV(p){ const r=await fetch(p); return Papa.parse(await r.tex
       });
     }).catch(()=>[]));
   const edges=await loadCSV('data/edges.csv').catch(()=>[]);
-  const nodes=problems.map(p=>({ data:{ id:p.id, label:p.title, route:p.route||'NA', sector:p.sector||'other' } }));
+  let micmacById=null;
+  try{
+    const micmacRows=await loadCSV('docs/data/micmac.csv');
+    const cleaned=micmacRows.filter(r=>r.id && r.micmac_class);
+    if(cleaned.length){
+      micmacById=Object.fromEntries(cleaned.map(r=>[r.id,r.micmac_class]));
+    }
+  }catch(e){
+    micmacById=null;
+  }
+  const nodes=problems.map(p=>({ data:{ id:p.id, label:p.title, route:p.route||'NA', sector:p.sector||'other', micmac:micmacById?.[p.id]||null } }));
   const links=edges.map(e=>({ data:{ id:e.source+'_'+e.target, source:e.source, target:e.target, weight:+e.weight||1 } }));
+  const baseStyle=[
+    { selector:'node', style:{ 'label':'data(label)','font-size':10,'background-color':'#888','text-wrap':'wrap','text-max-width':120 } },
+    { selector:'edge', style:{ 'curve-style':'bezier','width':'data(weight)','line-color':'#bbb' } }
+  ];
+  const style = micmacById ? baseStyle.concat([
+    { selector:'node[micmac = "Driver"]', style:{ 'background-color':'#065f46' } },
+    { selector:'node[micmac = "Linkage"]', style:{ 'background-color':'#d97706' } },
+    { selector:'node[micmac = "Dependent"]', style:{ 'background-color':'#2563eb' } },
+    { selector:'node[micmac = "Autonomous"]', style:{ 'background-color':'#9ca3af' } }
+  ]) : baseStyle.concat([
+    { selector:'node[route = "EXPLORE"]', style:{ 'background-color':'#f59e0b' } },
+    { selector:'node[route = "COMMIT"]',  style:{ 'background-color':'#10b981' } }
+  ]);
   const cy = cytoscape({ container:document.getElementById('cy'), elements:[...nodes,...links],
-    layout:{ name:'cose' }, style:[
-      { selector:'node', style:{ 'label':'data(label)','font-size':10,'background-color':'#888','text-wrap':'wrap','text-max-width':120 } },
-      { selector:'edge', style:{ 'curve-style':'bezier','width':'data(weight)','line-color':'#bbb' } },
-      { selector:'node[route = "EXPLORE"]', style:{ 'background-color':'#f59e0b' } },
-      { selector:'node[route = "COMMIT"]',  style:{ 'background-color':'#10b981' } }
-    ]});
+    layout:{ name:'cose' }, style });
   if(nodes.length===0){
     document.getElementById('msg').textContent =
       'داده‌ای پیدا نشد. منتظر خروجی CI بمانید یا فایل‌های data/* را پر کنید.';


### PR DESCRIPTION
## Summary
- load optional MICMAC CSV to attach classification metadata to nodes
- switch node color scheme to MICMAC categories when the file is available while preserving the existing route-based colors as a fallback

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db908f9e808328890a683c40c1f073