### PR TITLE
Add context for analyze workflow permissions

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -6,6 +6,7 @@ on:
     paths: ["data/**","analysis/python/**","web/**"]
 jobs:
   build:
+    # Allow docs updates to be pushed back to the repository
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- document why the analyze workflow requires `contents: write` permissions on the build job

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db98a6b5908328880531ea199f29c9