### PR TITLE
Ensure analysis tests install pytest

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -21,6 +21,14 @@ jobs:
       - run: python analysis/python/micmac.py
       - run: python analysis/python/ism.py
       - run: python analysis/python/reports.py
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r analysis/python/requirements.txt
+          # نصب صریح pytest برای اطمینان (اگر در requirements نبود/کش وجود داشت)
+          pip install -U pytest
+      - name: Run unit tests
+        run: python3 -m pytest -q analysis/python/tests
       - name: Commit docs
         run: |
           git config user.name "ci-bot"

--- a/analysis/python/requirements.txt
+++ b/analysis/python/requirements.txt
@@ -3,3 +3,4 @@ numpy
 networkx
 matplotlib
 jinja2
+pytest>=8,<9

--- a/analysis/python/tests/test_outputs.py
+++ b/analysis/python/tests/test_outputs.py
@@ -1,0 +1,28 @@
+import os, csv
+
+
+def _read_rows(path):
+    assert os.path.exists(path), f"missing artifact: {path}"
+    with open(path, newline='', encoding='utf-8') as f:
+        return list(csv.DictReader(f))
+
+
+def test_problems_enriched_exists_and_nonempty():
+    rows = _read_rows('docs/data/problems_enriched.csv')
+    assert len(rows) >= 1, "problems_enriched.csv must have at least 1 row"
+
+
+def test_micmac_when_edges_exist():
+    # MICMAC می‌تواند خالی باشد اگر edges نداریم؛ در غیر اینصورت باید حداقل 1 ردیف داشته باشد
+    edges_path = 'data/edges.csv'
+    edges_rows = 0
+    if os.path.exists(edges_path):
+        with open(edges_path, newline='', encoding='utf-8') as f:
+            edges_rows = max(0, sum(1 for _ in f) - 1)  # minus header
+    micmac = _read_rows('docs/data/micmac.csv')
+    if edges_rows > 0:
+        assert len(micmac) >= 1, "micmac.csv should not be empty when edges exist"
+
+
+def test_ism_levels_exists():
+    _ = _read_rows('docs/data/ism_levels.csv')


### PR DESCRIPTION
## Summary
- add pytest as an analysis dependency so artifact checks can import it
- ensure the analyze workflow installs pytest before running the CSV artifact tests
- update the artifact test file to read required CSVs and validate expected rows

## Testing
- python3 -m pytest -q analysis/python/tests

------
https://chatgpt.com/codex/tasks/task_e_68dbc0e332d083289a7a74be758053f9